### PR TITLE
[Resolve #2] Relational data

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -23,8 +23,8 @@ Or install it yourself as:
 - seedに関わらずどこからでも使える
 - CSV, YAML からデータを投入できる
 - 投入しようとするデータが既にある場合、何もしないか更新するか選択できる
+- Relational Data の投入
 - ~~Pure Ruby~~ (現状はまだ Rails 依存のコードがあるが、将来的には Pure Ruby による実装にしたい)
-- ~~Relational Data の投入~~ (将来的に実装する)
 - inspired by [sprig](https://github.com/vigetlabs/sprig)
 
 ## 使い方

--- a/README.ja.md
+++ b/README.ja.md
@@ -133,10 +133,10 @@ sowing.create(Book)
 `filename` を指定しない場合、`klass` をsnake cake の複数形に変換した名前で CSV か YAML ファイル を `db/seeds` 以下に探しに行きます。(例えば、`klass` が `User` の場合、 `users.(csv|yaml|yml)` を探します。)
 `filename` を指定する場合、 `new_users.csv` のように拡張子も含めて指定してください。
 
-### create_or_do_nothing(klass, finding_key, filename: nil)
+### create_or_skip(klass, finding_key, filename: nil)
 
 `#create` とほぼ同じですが、 `finding_key` で指定したカラムでDBを探索して一致するデータが見つかった場合、何もしません。
-同じスクリプトを複数回実行する可能性がある場合、 `create` より `create_or_do_nothing` を使用することを推奨します。
+同じスクリプトを複数回実行する可能性がある場合、 `create` より `create_or_skip` を使用することを推奨します。
 
 例:
 
@@ -146,15 +146,15 @@ sowing.create(Book)
 runner = Sowing::Runner.new
 
 # 1度目のデータ投入なので、users.csv からデータを投入する
-runner.create_or_do_nothing(User, :first_name)
+runner.create_or_skip(User, :first_name)
 
 # 上記で投入されたデータが存在するため、何もしない。
-runner.create_or_do_nothing(User, :first_name)
+runner.create_or_skip(User, :first_name)
 ```
 
 ### create_or_update(klass, finding_key, filename: nil)
 
-`#create_or_do_nothing` とほぼ同じですが、`finding_key` で指定したカラムでDBを探索して一致するデータが見つかった場合、
+`#create_or_skip` とほぼ同じですが、`finding_key` で指定したカラムでDBを探索して一致するデータが見つかった場合、
 データを更新します。
 
 例:
@@ -165,11 +165,11 @@ runner.create_or_do_nothing(User, :first_name)
 runner = Sowing::Runner.new
 
 # 1度目のデータ投入なので、users.csv からデータを投入する
-runner.create_or_do_nothing(User, :first_name)
+runner.create_or_skip(User, :first_name)
 
 # users.csv と update_users.csv で同じ first_name のデータがある場合は update_users.csv の内容で上書きする
 # update_users.csv にしかないデータは新規作成する
-runner.create_or_do_nothing(User, :first_name, filename: 'update_users.csv')
+runner.create_or_skip(User, :first_name, filename: 'update_users.csv')
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -37,6 +37,46 @@ runner.create_or_update(User, :first_name)
 sowing = Sowing::Runner.new(data_directory: Rails.root.join('db/seeds/development'))
 ```
 
+### Relational Data
+
+For example, the following files exist:
+
+`users.csv`
+
+```csv
+first_name,last_name
+Carlotta,Wilkinson
+中平,薫
+```
+
+`profiles.csv`
+
+```csv
+user_id,address,phone
+"first_name: Carlotta, last_name: Wilkinson","2001 N Clark St, Chicago, IL 60614 America","+1 111-222-3333"
+"first_name: 中平, last_name: 薫","東京都新宿区新宿1-1-1","090-1111-2222"
+```
+
+And, the ruby code using sowing:
+
+```ruby
+require 'sowing'
+
+runner = Sowing::Runner.new
+
+runner.create(User)
+runner.create(Profile) do
+  mapping :user_id do |cel|
+    # cel #=> {'first_name' => 'Carlotta', 'last_name' => 'Wilkinson'}
+
+    User.find_by(
+      first_name: cel['first_name'],
+      last_name: cel['last_name']
+    ).id # Must be return user id
+  end
+end
+```
+
 ## Development
 
 ### Run tests

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ runner = Sowing::Runner.new
 # if exist db/seeds/users.(csv|yaml|yml), read data
 runner.create(User)
 
-runner.create_or_do_nothing(User, :first_name)
+runner.create_or_skip(User, :first_name)
 runner.create_or_update(User, :first_name)
 
 # change data root directory

--- a/lib/sowing.rb
+++ b/lib/sowing.rb
@@ -1,4 +1,6 @@
 module Sowing
+  class DataFileNotFound < StandardError; end
+  class StrategyNotFound < StandardError; end
 end
 
 require 'pathname'

--- a/lib/sowing.rb
+++ b/lib/sowing.rb
@@ -11,4 +11,5 @@ require_relative 'sowing/version'
 
 require_relative 'sowing/configuration'
 require_relative 'sowing/definition_proxy'
+require_relative 'sowing/file_selector'
 require_relative 'sowing/runner'

--- a/lib/sowing.rb
+++ b/lib/sowing.rb
@@ -11,5 +11,5 @@ require_relative 'sowing/version'
 
 require_relative 'sowing/configuration'
 require_relative 'sowing/definition_proxy'
-require_relative 'sowing/file_selector'
+require_relative 'sowing/selector'
 require_relative 'sowing/runner'

--- a/lib/sowing.rb
+++ b/lib/sowing.rb
@@ -10,4 +10,5 @@ require_relative 'sowing/strategies'
 require_relative 'sowing/version'
 
 require_relative 'sowing/configuration'
+require_relative 'sowing/definition_proxy'
 require_relative 'sowing/runner'

--- a/lib/sowing/definition_proxy.rb
+++ b/lib/sowing/definition_proxy.rb
@@ -1,0 +1,5 @@
+class Sowing::DefinitionProxy
+  def mapping(attr)
+    p attr
+  end
+end

--- a/lib/sowing/definition_proxy.rb
+++ b/lib/sowing/definition_proxy.rb
@@ -1,5 +1,11 @@
 class Sowing::DefinitionProxy
-  def mapping(attr)
-    p attr
+  attr_reader :mappings
+
+  def initialize
+    @mappings = {}
+  end
+
+  def mapping(attr, &block)
+    @mappings[attr.to_s] = block
   end
 end

--- a/lib/sowing/file_selector.rb
+++ b/lib/sowing/file_selector.rb
@@ -1,0 +1,45 @@
+# TODO rename
+class Sowing::FileSelector
+  attr_reader :data_directory
+
+  def initialize(data_directory)
+    @data_directory = data_directory
+  end
+
+  def find(klass, filename = nil)
+    if filename
+      find_file_from_filename(filename)
+    else
+      file_file_from_convention(klass)
+    end
+  end
+
+  private
+
+  def find_file_from_filename(filename)
+    file = data_directory.join(filename)
+
+    raise DataFileNotFound.new("not found: #{file}") unless file.exist?
+
+    [file, select_strategy(file.extname[1..-1])]
+  end
+
+  def file_file_from_convention(klass)
+    pathname = data_directory.join(klass.to_s.underscore.pluralize)
+    ext = Sowing::Configuration.config.extensions.find {|ext| Pathname("#{pathname}.#{ext}").exist? }
+
+    raise DataFileNotFound.new("not found: #{pathanme}.(#{Sowing::Configuration.config.extensions.join('|')})") unless ext
+
+    [Pathname("#{pathname}.#{ext}"), select_strategy(ext)]
+  end
+
+  def select_strategy(ext)
+    strategy_klass = Sowing::Configuration.config.strategies[ext]
+
+    if strategy_klass
+      strategy_klass.new
+    else
+      raise StrategyNotFound.new("strategy not found: extension #{ext}")
+    end
+  end
+end

--- a/lib/sowing/runner.rb
+++ b/lib/sowing/runner.rb
@@ -38,7 +38,7 @@ class Sowing::Runner
 
     strategy.read_data(file).map {|row|
       proxy.mappings.each do |key, pproc|
-        # TODO skipできるときはした方が早くなるはず
+        # TODO if i can skip, i want to skip. Doing so will increase performance
         row[key.to_s] = pproc[string_to_hash(row.fetch(key.to_s))]
       end
 

--- a/lib/sowing/runner.rb
+++ b/lib/sowing/runner.rb
@@ -14,6 +14,7 @@ class Sowing::Runner
     end
   end
 
+  # TODO rename "create_or_skip"
   def create_or_do_nothing(klass, finding_key, filename: nil, &block)
     file, strategy = @selector.find(klass, filename)
 
@@ -38,6 +39,7 @@ class Sowing::Runner
 
     strategy.read_data(file).map {|row|
       proxy.mappings.each do |key, pproc|
+        # TODO skipできるときはした方が早くなるはず
         row[key.to_s] = pproc[string_to_hash(row.fetch(key.to_s))]
       end
 

--- a/lib/sowing/runner.rb
+++ b/lib/sowing/runner.rb
@@ -14,12 +14,11 @@ class Sowing::Runner
     end
   end
 
-  # TODO rename "create_or_skip"
-  def create_or_do_nothing(klass, finding_key, filename: nil, &block)
+  def create_or_skip(klass, finding_key, filename: nil, &block)
     file, strategy = @selector.find(klass, filename)
 
     create_rows(file, strategy, &block).each do |row|
-      strategy.create_or_do_nothing(klass, row, finding_key)
+      strategy.create_or_skip(klass, row, finding_key)
     end
   end
 

--- a/lib/sowing/runner.rb
+++ b/lib/sowing/runner.rb
@@ -3,11 +3,11 @@ class Sowing::Runner
 
   def initialize(data_directory: nil)
     @data_directory = Pathname(data_directory || Sowing::Configuration.config.default_data_directory)
-    @file_selector = Sowing::FileSelector.new(@data_directory)
+    @selector = Sowing::Selector.new(@data_directory)
   end
 
   def create(klass, filename: nil, &block)
-    file, strategy = @file_selector.find(klass, filename)
+    file, strategy = @selector.find(klass, filename)
 
     create_rows(file, strategy, &block).each do |row|
       strategy.create(klass, row)
@@ -15,7 +15,7 @@ class Sowing::Runner
   end
 
   def create_or_do_nothing(klass, finding_key, filename: nil, &block)
-    file, strategy = @file_selector.find(klass, filename)
+    file, strategy = @selector.find(klass, filename)
 
     create_rows(file, strategy, &block).each do |row|
       strategy.create_or_do_nothing(klass, row, finding_key)
@@ -23,7 +23,7 @@ class Sowing::Runner
   end
 
   def create_or_update(klass, finding_key, filename: nil, &block)
-    file, strategy = @file_selector.find(klass, filename)
+    file, strategy = @selector.find(klass, filename)
 
     create_rows(file, strategy, &block).each do |row|
       strategy.create_or_update(klass, row, finding_key)

--- a/lib/sowing/runner.rb
+++ b/lib/sowing/runner.rb
@@ -1,25 +1,34 @@
 class Sowing::Runner
-  attr_reader :data_directory
+  attr_reader :data_directory, :proxy
 
   def initialize(data_directory: nil)
     @data_directory = Pathname(data_directory || Sowing::Configuration.config.default_data_directory)
+    @proxy = Sowing::DefinitionProxy.new
   end
 
-  def create(klass, filename: nil)
+  def create(klass, filename: nil, &block)
+    # proxy.instance_eval(&block) if block_given?
+
     find_file(klass, filename: filename) do |file, strategy|
-      strategy.create(klass, file)
+      strategy.read_data(file).each do |row|
+        strategy.create(klass, row)
+      end
     end
   end
 
   def create_or_do_nothing(klass, finding_key, filename: nil)
     find_file(klass, filename: filename) do |file, strategy|
-      strategy.create_or_do_nothing(klass, file, finding_key)
+      strategy.read_data(file).each do |row|
+        strategy.create_or_do_nothing(klass, row, finding_key)
+      end
     end
   end
 
   def create_or_update(klass, finding_key, filename: nil)
     find_file(klass, filename: filename) do |file, strategy|
-      strategy.create_or_update(klass, file, finding_key)
+      strategy.read_data(file).each do |row|
+        strategy.create_or_update(klass, row, finding_key)
+      end
     end
   end
 

--- a/lib/sowing/runner.rb
+++ b/lib/sowing/runner.rb
@@ -1,68 +1,51 @@
 class Sowing::Runner
-  attr_reader :data_directory, :proxy
+  attr_reader :data_directory
 
   def initialize(data_directory: nil)
     @data_directory = Pathname(data_directory || Sowing::Configuration.config.default_data_directory)
-    @proxy = Sowing::DefinitionProxy.new
+    @file_selector = Sowing::FileSelector.new(@data_directory)
   end
 
   def create(klass, filename: nil, &block)
-    # proxy.instance_eval(&block) if block_given?
+    file, strategy = @file_selector.find(klass, filename)
 
-    find_file(klass, filename: filename) do |file, strategy|
-      strategy.read_data(file).each do |row|
-        strategy.create(klass, row)
-      end
+    create_rows(file, strategy, &block).each do |row|
+      strategy.create(klass, row)
     end
   end
 
-  def create_or_do_nothing(klass, finding_key, filename: nil)
-    find_file(klass, filename: filename) do |file, strategy|
-      strategy.read_data(file).each do |row|
-        strategy.create_or_do_nothing(klass, row, finding_key)
-      end
+  def create_or_do_nothing(klass, finding_key, filename: nil, &block)
+    file, strategy = @file_selector.find(klass, filename)
+
+    create_rows(file, strategy, &block).each do |row|
+      strategy.create_or_do_nothing(klass, row, finding_key)
     end
   end
 
-  def create_or_update(klass, finding_key, filename: nil)
-    find_file(klass, filename: filename) do |file, strategy|
-      strategy.read_data(file).each do |row|
-        strategy.create_or_update(klass, row, finding_key)
-      end
+  def create_or_update(klass, finding_key, filename: nil, &block)
+    file, strategy = @file_selector.find(klass, filename)
+
+    create_rows(file, strategy, &block).each do |row|
+      strategy.create_or_update(klass, row, finding_key)
     end
   end
 
   private
 
-  def find_file(klass, filename: nil)
-    if filename
-      file = data_directory.join(filename)
-      if file.exist?
-        yield(file, select_strategy(file.extname[1..-1]))
-      else
-        raise DataFileNotFound.new("not found: #{file}")
+  def create_rows(file, strategy, &block)
+    proxy = Sowing::DefinitionProxy.new
+    proxy.instance_exec(&block) if block_given?
+
+    strategy.read_data(file).map {|row|
+      proxy.mappings.each do |key, pproc|
+        row[key.to_s] = pproc[string_to_hash(row.fetch(key.to_s))]
       end
 
-      return
-    end
-
-    pathname = data_directory.join(klass.to_s.underscore.pluralize)
-    ext = Sowing::Configuration.config.extensions.find {|ext| Pathname("#{pathname}.#{ext}").exist? }
-
-    if ext
-      yield(Pathname("#{pathname}.#{ext}"), select_strategy(ext))
-    else
-      raise DataFileNotFound.new("not found: #{pathanme}.(#{Sowing::Configuration.config.extensions.join('|')})")
-    end
+      row
+    }
   end
 
-  def select_strategy(ext)
-    strategy_klass = Sowing::Configuration.config.strategies[ext]
-
-    if strategy_klass
-      strategy_klass.new
-    else
-      raise StrategyNotFound.new("strategy not found: extension #{ext}")
-    end
+  def string_to_hash(str)
+    str.delete(' ').split(/[:,]/).each_slice(2).to_h
   end
 end

--- a/lib/sowing/runner.rb
+++ b/lib/sowing/runner.rb
@@ -31,7 +31,7 @@ class Sowing::Runner
       if file.exist?
         yield(file, select_strategy(file.extname[1..-1]))
       else
-        raise "not found: #{file}"
+        raise DataFileNotFound.new("not found: #{file}")
       end
 
       return
@@ -43,7 +43,7 @@ class Sowing::Runner
     if ext
       yield(Pathname("#{pathname}.#{ext}"), select_strategy(ext))
     else
-      raise "not found: #{pathanme}.(#{Sowing::Configuration.config.extensions.join('|')})"
+      raise DataFileNotFound.new("not found: #{pathanme}.(#{Sowing::Configuration.config.extensions.join('|')})")
     end
   end
 
@@ -53,7 +53,7 @@ class Sowing::Runner
     if strategy_klass
       strategy_klass.new
     else
-      raise "strategy not found: extension #{ext}"
+      raise StrategyNotFound.new("strategy not found: extension #{ext}")
     end
   end
 end

--- a/lib/sowing/selector.rb
+++ b/lib/sowing/selector.rb
@@ -1,11 +1,11 @@
-# TODO rename
-class Sowing::FileSelector
+class Sowing::Selector
   attr_reader :data_directory
 
   def initialize(data_directory)
     @data_directory = data_directory
   end
 
+  # @return [Array<Pathname, Sowing::Strategies>]
   def find(klass, filename = nil)
     if filename
       find_file_from_filename(filename)

--- a/lib/sowing/strategies/abstract_strategy.rb
+++ b/lib/sowing/strategies/abstract_strategy.rb
@@ -5,7 +5,7 @@ module Sowing
         raise NotImplementedError
       end
 
-      def create_or_do_nothing(klass, row, finding_key)
+      def create_or_skip(klass, row, finding_key)
         raise NotImplementedError
       end
 

--- a/lib/sowing/strategies/abstract_strategy.rb
+++ b/lib/sowing/strategies/abstract_strategy.rb
@@ -21,6 +21,8 @@ module Sowing
       private
 
       def print_object_info(object)
+        return if ENV['SOWING_QUIET']
+
         print 'create: '
         p object
       end

--- a/lib/sowing/strategies/abstract_strategy.rb
+++ b/lib/sowing/strategies/abstract_strategy.rb
@@ -1,15 +1,20 @@
 module Sowing
   module Strategies
     class AbstractStrategy
-      def create(klass, csv_filename)
+      def create(klass, row)
         raise NotImplementedError
       end
 
-      def create_or_do_nothing(klass, csv_filename, finding_key)
+      def create_or_do_nothing(klass, row, finding_key)
         raise NotImplementedError
       end
 
-      def create_or_update(klass, csv_filename, finding_key)
+      def create_or_update(klass, row, finding_key)
+        raise NotImplementedError
+      end
+
+      # @return [Enumerable] object
+      def read_data(filename)
         raise NotImplementedError
       end
 

--- a/lib/sowing/strategies/active_record_abstract.rb
+++ b/lib/sowing/strategies/active_record_abstract.rb
@@ -1,37 +1,25 @@
 module Sowing
   module Strategies
     class ActiveRecordAbstract < AbstractStrategy
-      def create(klass, filename)
-        read_data(filename).each do |row|
-          object = klass.create!(row.to_hash)
+      def create(klass, row)
+        object = klass.create!(row.to_hash)
 
-          print_object_info(object)
-        end
+        print_object_info(object)
       end
 
-      def create_or_do_nothing(klass, filename, finding_key)
-        read_data(filename).each do |row|
-          klass.find_or_initialize_by(finding_key => row[finding_key.to_s]) do |object|
-            object.update!(row.to_hash)
-
-            print_object_info(object)
-          end
-        end
-      end
-
-      def create_or_update(klass, filename, finding_key)
-        read_data(filename).each do |row|
-          object = klass.find_or_initialize_by(finding_key => row[finding_key.to_s])
+      def create_or_do_nothing(klass, row, finding_key)
+        klass.find_or_initialize_by(finding_key => row[finding_key.to_s]) do |object|
           object.update!(row.to_hash)
 
           print_object_info(object)
         end
       end
 
-      private
+      def create_or_update(klass, row, finding_key)
+        object = klass.find_or_initialize_by(finding_key => row[finding_key.to_s])
+        object.update!(row.to_hash)
 
-      def read_data(filename)
-        raise NotImplementedError
+        print_object_info(object)
       end
     end
   end

--- a/lib/sowing/strategies/active_record_abstract.rb
+++ b/lib/sowing/strategies/active_record_abstract.rb
@@ -7,7 +7,7 @@ module Sowing
         print_object_info(object)
       end
 
-      def create_or_do_nothing(klass, row, finding_key)
+      def create_or_skip(klass, row, finding_key)
         klass.find_or_initialize_by(finding_key => row[finding_key.to_s]) do |object|
           object.update!(row.to_hash)
 

--- a/lib/sowing/strategies/active_record_csv.rb
+++ b/lib/sowing/strategies/active_record_csv.rb
@@ -3,8 +3,6 @@ require 'csv'
 module Sowing
   module Strategies
     class ActiveRecordCsv < ActiveRecordAbstract
-      private
-
       def read_data(csv_filename)
         CSV.read(csv_filename, headers: true)
       end

--- a/lib/sowing/strategies/active_record_yaml.rb
+++ b/lib/sowing/strategies/active_record_yaml.rb
@@ -3,8 +3,6 @@ require 'yaml'
 module Sowing
   module Strategies
     class ActiveRecordYaml < ActiveRecordAbstract
-      private
-
       def read_data(yaml_filename)
         YAML.load_file(yaml_filename).values
       end

--- a/test/fixtures/csv/profiles.csv
+++ b/test/fixtures/csv/profiles.csv
@@ -1,0 +1,3 @@
+user_id,address,phone
+"first_name: Carlotta, last_name: Wilkinson","2001 N Clark St, Chicago, IL 60614 America","+1 312-742-2000"
+"first_name: 中平, last_name: 薫","東京都新宿区新宿1-1-1","090-1111-2222"

--- a/test/fixtures/csv/update_profiles.csv
+++ b/test/fixtures/csv/update_profiles.csv
@@ -1,0 +1,2 @@
+user_id,address,phone
+"first_name: Carlotta, last_name: Wilkinson","4548 Sweetwater Rd, Bonita, CA 91902 America","+1 312-742-2000"

--- a/test/fixtures/models/profile.rb
+++ b/test/fixtures/models/profile.rb
@@ -1,0 +1,9 @@
+# user_id  :integer
+# address  :string
+# phone    :string
+#
+class Profile < ActiveRecord::Base
+  belongs_to :user
+
+  validates_presence_of :user_id, :phone
+end

--- a/test/fixtures/models/user.rb
+++ b/test/fixtures/models/user.rb
@@ -3,4 +3,5 @@
 #
 class User < ActiveRecord::Base
   validates_presence_of :first_name, :last_name
+  has_one :profile
 end

--- a/test/fixtures/yaml/profiles.yml
+++ b/test/fixtures/yaml/profiles.yml
@@ -1,0 +1,8 @@
+profile_1:
+  user_id: 'first_name: Carlotta, last_name: Wilkinson'
+  address: '2001 N Clark St, Chicago, IL 60614 America'
+  phone: '+1 312-742-2000'
+profile_2:
+  user_id: 'first_name: 中平, last_name: 薫'
+  address: '東京都新宿区新宿1-1-1'
+  phone: '090-1111-2222'

--- a/test/fixtures/yaml/update_profiles.yml
+++ b/test/fixtures/yaml/update_profiles.yml
@@ -1,0 +1,4 @@
+profile_1:
+  user_id: 'first_name: Carlotta, last_name: Wilkinson'
+  address: '4548 Sweetwater Rd, Bonita, CA 91902 America'
+  phone: '+1 312-742-2000'

--- a/test/lib/strategies/test_active_record_csv.rb
+++ b/test/lib/strategies/test_active_record_csv.rb
@@ -38,4 +38,84 @@ class Strategies::TestActiveRecordCsv < Sowing::TestBase
     assert { user.created_at != user.updated_at }
     assert { user.last_name == 'Waelchi' }
   end
+
+  sub_test_case 'relational data' do
+    setup do
+      @runner.create(User)
+    end
+
+    test 'insert' do
+      @runner.create(Profile) do
+        mapping :user_id do |cel|
+          User.find_by(
+            first_name: cel['first_name'],
+            last_name: cel['last_name']
+          ).id
+        end
+      end
+
+      profile1 = Profile.find_by!(phone: '+1 312-742-2000')
+      assert { profile1.address == '2001 N Clark St, Chicago, IL 60614 America' }
+      assert { profile1.user.first_name == 'Carlotta' }
+      assert { profile1.user.last_name == 'Wilkinson' }
+
+      profile2 = Profile.find_by!(phone: '090-1111-2222')
+      assert { profile2.address == '東京都新宿区新宿1-1-1' }
+      assert { profile2.user.first_name == '中平' }
+      assert { profile2.user.last_name == '薫' }
+    end
+
+    test 'insert or do nothing' do
+      2.times do
+        @runner.create_or_skip(Profile, :phone) do
+          mapping :user_id do |cel|
+            User.find_by(
+              first_name: cel['first_name'],
+              last_name: cel['last_name']
+            ).id
+          end
+        end
+      end
+
+      assert { Profile.where(phone: '+1 312-742-2000').count == 1 }
+
+      profile = Profile.find_by!(phone: '+1 312-742-2000')
+      assert { profile.address == '2001 N Clark St, Chicago, IL 60614 America' }
+      assert { profile.user.first_name == 'Carlotta' }
+      assert { profile.user.last_name == 'Wilkinson' }
+      assert { profile.created_at == profile.updated_at }
+    end
+
+    test 'insert or update' do
+      @runner.create_or_update(Profile, :phone) do
+        mapping :user_id do |cel|
+          User.find_by(
+            first_name: cel['first_name'],
+            last_name: cel['last_name']
+          ).id
+        end
+      end
+
+      profile = Profile.find_by!(phone: '+1 312-742-2000')
+      assert { profile.address == '2001 N Clark St, Chicago, IL 60614 America' }
+      assert { profile.user.first_name == 'Carlotta' }
+      assert { profile.user.last_name == 'Wilkinson' }
+
+      @runner.create_or_update(Profile, :phone, filename: 'update_profiles.csv') do
+        mapping :user_id do |cel|
+          User.find_by(
+            first_name: cel['first_name'],
+            last_name: cel['last_name']
+          ).id
+        end
+      end
+
+      assert { Profile.where(phone: '+1 312-742-2000').count == 1 }
+
+      profile.reload
+      assert { profile.address == '4548 Sweetwater Rd, Bonita, CA 91902 America' }
+      assert { profile.user.first_name == 'Carlotta' }
+      assert { profile.user.last_name == 'Wilkinson' }
+    end
+  end
 end

--- a/test/lib/strategies/test_active_record_csv.rb
+++ b/test/lib/strategies/test_active_record_csv.rb
@@ -11,12 +11,12 @@ class Strategies::TestActiveRecordCsv < Sowing::TestBase
   end
 
   test 'insert users or do nothing form csv' do
-    @runner.create_or_do_nothing(User, :first_name)
+    @runner.create_or_skip(User, :first_name)
 
     assert { match_array?(User.pluck(:first_name), %w(Carlotta 中平)) }
     assert { match_array?(User.pluck(:last_name), %w(Wilkinson 薫)) }
 
-    @runner.create_or_do_nothing(User, :first_name)
+    @runner.create_or_skip(User, :first_name)
 
     assert { User.where(first_name: 'Carlotta').count == 1 }
 

--- a/test/lib/strategies/test_active_record_yaml.rb
+++ b/test/lib/strategies/test_active_record_yaml.rb
@@ -11,12 +11,12 @@ class Strategies::TestActiveRecordYaml < Sowing::TestBase
   end
 
   test 'insert users or do nothing form yaml' do
-    @runner.create_or_do_nothing(User, :first_name)
+    @runner.create_or_skip(User, :first_name)
 
     assert { match_array?(User.pluck(:first_name), %w(Carlotta 中平)) }
     assert { match_array?(User.pluck(:last_name), %w(Wilkinson 薫)) }
 
-    @runner.create_or_do_nothing(User, :first_name)
+    @runner.create_or_skip(User, :first_name)
 
     assert { User.where(first_name: 'Carlotta').count == 1 }
 
@@ -67,7 +67,7 @@ class Strategies::TestActiveRecordYaml < Sowing::TestBase
 
     test 'insert or do nothing' do
       2.times do
-        @runner.create_or_do_nothing(Profile, :phone) do
+        @runner.create_or_skip(Profile, :phone) do
           mapping :user_id do |cel|
             User.find_by(
               first_name: cel['first_name'],

--- a/test/lib/strategies/test_active_record_yaml.rb
+++ b/test/lib/strategies/test_active_record_yaml.rb
@@ -38,4 +38,24 @@ class Strategies::TestActiveRecordYaml < Sowing::TestBase
     assert { user.created_at != user.updated_at }
     assert { user.last_name == 'Waelchi' }
   end
+
+  test 'insert relational data' do
+    @runner.create(User)
+
+    # TODO 次のインタフェースでルールを定義できるようにしたい。
+    @runner.create(Profile) do
+      mapping :user_id do |first_name, last_name|
+        User.find_by(
+          first_name: hash_string[:first_name],
+          last_name:  hash_string[:last_name]
+        ).id
+      end
+    end
+
+    profile = Profile.find_by(phone: '+1 312-742-2000')
+
+    assert { profile.phone == '+1 312-742-2000' }
+    assert { profile.address == '2001 N Clark St, Chicago, IL 60614 America' }
+    assert { profile.user.first_name == 'Carlotta' }
+  end
 end

--- a/test/lib/strategies/test_active_record_yaml.rb
+++ b/test/lib/strategies/test_active_record_yaml.rb
@@ -42,12 +42,11 @@ class Strategies::TestActiveRecordYaml < Sowing::TestBase
   test 'insert relational data' do
     @runner.create(User)
 
-    # TODO 次のインタフェースでルールを定義できるようにしたい。
     @runner.create(Profile) do
-      mapping :user_id do |first_name, last_name|
+      mapping :user_id do |hash|
         User.find_by(
-          first_name: hash_string[:first_name],
-          last_name:  hash_string[:last_name]
+          first_name: hash['first_name'],
+          last_name: hash['last_name']
         ).id
       end
     end

--- a/test/run-test.rb
+++ b/test/run-test.rb
@@ -18,11 +18,22 @@ require 'database_cleaner'
 ### migration
 ActiveRecord::Base.establish_connection(adapter: 'sqlite3', database: 'tmp/activerecord.db')
 ActiveRecord::Base.connection.execute('DROP TABLE IF EXISTS users;')
+ActiveRecord::Base.connection.execute('DROP TABLE IF EXISTS profiles;')
 ActiveRecord::Base.connection.execute(<<-SQL)
 CREATE TABLE users (
-  id INTEGER PRIMARY KEY,
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
   first_name VARCHAR(255),
   last_name VARCHAR(255),
+  created_at TIMESTAMP DATETIME DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+SQL
+ActiveRecord::Base.connection.execute(<<-SQL)
+CREATE TABLE profiles (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id INTEGER,
+  address VARCHAR(255),
+  phone VARCHAR(255),
   created_at TIMESTAMP DATETIME DEFAULT CURRENT_TIMESTAMP,
   updated_at TIMESTAMP DATETIME DEFAULT CURRENT_TIMESTAMP
 );

--- a/test/run-test.rb
+++ b/test/run-test.rb
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
 
+ENV['SOWING_QUIET'] = 'true'
+
 ## load path
 require 'pathname'
 


### PR DESCRIPTION
You can define relational data to pass the block to `create` , `create_or_skip`, and `create_or_update`

`users.csv`

```csv
first_name,last_name
Carlotta,Wilkinson
中平,薫
```

`profiles.csv`

```csv
user_id,address,phone
"first_name: Carlotta, last_name: Wilkinson","2001 N Clark St, Chicago, IL 60614 America","+1 111-222-3333"
"first_name: 中平, last_name: 薫","東京都新宿区新宿1-1-1","090-1111-2222"
```

ruby:

```ruby
require 'sowing'

runner = Sowing::Runner.new

runner.create(User)
runner.create(Profile) do
  mapping :user_id do |cel|
    User.find_by(
      first_name: cel['first_name'],
      last_name: cel['last_name']
    ).id
  end
end
```

`mapping` DSL receive key name (it must be match header key name in CSV or Yaml file ) and block.
In the database, the result of executing the block instead of the value of the CSV or Yaml file is recorded.

In this case, `profiles.user_id` contains the result of executing `User.find_by (first_name: cel['first_name '], last_name: cel['last_name']).Id` instead of `first_name: Carlotta, last_name: Wilkinson`.

For the argument of mapping block, the value obtained by converting the value of the CSV or Yaml file to  the hash object is assigned.
Then, convert string: `"first_name: Carlotta, last_name: Wilkinson"` to hash: `{"first_name" => "Carlotta", "last_name" => "Wilkinson"}`.